### PR TITLE
feat(sink): allow to configure and disable sink state

### DIFF
--- a/tool_intention.go
+++ b/tool_intention.go
@@ -20,15 +20,22 @@ func (i *intentionToolWrapper) NewArgs() *IntentionResponse {
 }
 
 // intentionTool creates a tool that forces the LLM to pick one of the available tools
-func intentionTool(toolNames []string) *ToolDefinition[IntentionResponse] {
+func intentionTool(toolNames []string, sinkStateName string) *ToolDefinition[IntentionResponse] {
 	// Build enum for the tool names
-	enumValues := append([]string{"reply"}, toolNames...)
+	enumValues := toolNames
+	if sinkStateName != "" {
+		enumValues = append(enumValues, sinkStateName)
+	}
 
+	description := "Pick the most appropriate tool to use based on the reasoning."
+	if sinkStateName != "" {
+		description += " Choose '" + sinkStateName + "' if no tool is needed."
+	}
 	return &ToolDefinition[IntentionResponse]{
 		ToolRunner: &intentionToolWrapper{},
 		Name:       "pick_tool",
 		InputArguments: map[string]interface{}{
-			"description": "Pick the most appropriate tool to use based on the reasoning. Choose 'reply' if no tool is needed.",
+			"description": description,
 			"type":        "object",
 			"properties": map[string]interface{}{
 				"tool": map[string]interface{}{


### PR DESCRIPTION
This PR adds the ability to customize or disable the "sink state" mechanism in Cogito. The sink state is used when the LLM decides that no tool execution is needed. Previously, this was hardcoded to "reply", but now it can be customized with a custom name and optional callback, or completely disabled.

By default, the sink state is **enabled** with the name `"reply"`. This maintains backward compatibility with existing code.

Examples:

**Disable Sink State:**

```go
// Disable sink state entirely - the LLM will return an error if no tool is selected
result, err := cogito.ExecuteTools(llm, fragment,
    cogito.WithTools(weatherTool, searchTool),
    cogito.DisableSinkState)
```

**Custom Sink State Tool:**

```go
// Define a custom sink state tool
type CustomReplyArgs struct {
    Reasoning string `json:"reasoning" description:"The reasoning for the reply"`
}

type CustomReplyTool struct{}

func (t *CustomReplyTool) Run(args CustomReplyArgs) (string, error) {
    // Custom logic to process the reasoning and generate a response
    return fmt.Sprintf("Based on: %s", args.Reasoning), nil
}

// Create a custom sink state tool
customSinkTool := cogito.NewToolDefinition(
    &CustomReplyTool{},
    CustomReplyArgs{},
    "custom_reply",
    "Custom tool for handling responses when no other tool is needed",
)

// Use the custom sink state tool
result, err := cogito.ExecuteTools(llm, fragment,
    cogito.WithTools(weatherTool, searchTool),
    cogito.WithSinkState(customSinkTool))
```

Notes:

This PR fixes https://github.com/mudler/cogito/issues/16

