### PR TITLE
fix(mcp): handle non-text tool result content without panicking

### DIFF
--- a/decision_messages_test.go
+++ b/decision_messages_test.go
@@ -1,0 +1,85 @@
+package cogito
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+// lastTwoAreAssistant reports whether the final two messages are both assistant
+// messages - the exact shape llama.cpp/LocalAI rejects with
+// "Cannot have 2 or more assistant messages at the end of the list".
+func lastTwoAreAssistant(msgs []openai.ChatCompletionMessage) bool {
+	if len(msgs) < 2 {
+		return false
+	}
+	return msgs[len(msgs)-1].Role == "assistant" && msgs[len(msgs)-2].Role == "assistant"
+}
+
+// TestMergeConsecutiveAssistantTrailing pins the fix for the e2e crash where the
+// reviewer tool loop appends a reasoning assistant message on top of a fragment
+// that already ends with an assistant message, producing a request that ends
+// with two assistant messages and is rejected by the backend (500
+// InvalidArgument). After merging, the list must not end with two assistant
+// messages, and the merged content must be preserved.
+func TestMergeConsecutiveAssistantTrailing(t *testing.T) {
+	conversation := []openai.ChatCompletionMessage{
+		{Role: "user", Content: "What are the latest news today?"},
+		{Role: "assistant", Content: "Here is a summary of the news."},
+		{Role: "assistant", Content: "Let me reason about which tool to use."},
+	}
+
+	merged := mergeConsecutiveAssistantMessages(conversation)
+
+	if lastTwoAreAssistant(merged) {
+		t.Fatalf("expected no two consecutive trailing assistant messages, got %d messages ending assistant/assistant", len(merged))
+	}
+	last := merged[len(merged)-1]
+	if last.Role != "assistant" {
+		t.Fatalf("expected merged tail to remain an assistant message, got role %q", last.Role)
+	}
+	for _, want := range []string{"Here is a summary of the news.", "Let me reason about which tool to use."} {
+		if !strings.Contains(last.Content, want) {
+			t.Fatalf("expected merged content to preserve %q, got %q", want, last.Content)
+		}
+	}
+}
+
+// TestMergeConsecutiveAssistantMiddle ensures a consecutive assistant run in the
+// middle of a conversation is also collapsed and tool calls are not dropped.
+func TestMergeConsecutiveAssistantMiddle(t *testing.T) {
+	conversation := []openai.ChatCompletionMessage{
+		{Role: "user", Content: "q"},
+		{Role: "assistant", ToolCalls: []openai.ToolCall{{ID: "1", Type: openai.ToolTypeFunction, Function: openai.FunctionCall{Name: "search"}}}},
+		{Role: "assistant", Content: "reasoning"},
+		{Role: "user", Content: "follow up"},
+	}
+
+	merged := mergeConsecutiveAssistantMessages(conversation)
+
+	if len(merged) != 3 {
+		t.Fatalf("expected the two assistant messages to collapse into one (3 total), got %d", len(merged))
+	}
+	if len(merged[1].ToolCalls) != 1 {
+		t.Fatalf("expected tool calls to be preserved through the merge, got %d", len(merged[1].ToolCalls))
+	}
+	if !strings.Contains(merged[1].Content, "reasoning") {
+		t.Fatalf("expected merged assistant content to contain %q, got %q", "reasoning", merged[1].Content)
+	}
+}
+
+// TestMergeConsecutiveAssistantNoOp leaves well-formed alternating conversations
+// untouched.
+func TestMergeConsecutiveAssistantNoOp(t *testing.T) {
+	conversation := []openai.ChatCompletionMessage{
+		{Role: "user", Content: "q"},
+		{Role: "assistant", Content: "a"},
+		{Role: "user", Content: "q2"},
+	}
+
+	merged := mergeConsecutiveAssistantMessages(conversation)
+	if len(merged) != 3 {
+		t.Fatalf("expected well-formed conversation to be unchanged (3 messages), got %d", len(merged))
+	}
+}

--- a/fragment_e2e_test.go
+++ b/fragment_e2e_test.go
@@ -174,13 +174,15 @@ var _ = Describe("Result test", Label("e2e"), func() {
 			json, err := json.Marshal(result.Arguments)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(newFragment.Messages[len(newFragment.Messages)-1].ToolCalls).To(HaveExactElements(openai.ToolCall{
-				Type: openai.ToolTypeFunction,
-				Function: openai.FunctionCall{
-					Name:      "get_weather",
-					Arguments: string(json),
-				},
-			}))
+			// The tool-call message preserves the model's raw arguments string,
+			// whose JSON whitespace may differ from a re-marshaled map (e.g.
+			// `{"city": "San Francisco"}` vs `{"city":"San Francisco"}`). Compare
+			// semantically rather than byte-for-byte.
+			toolCalls := newFragment.Messages[len(newFragment.Messages)-1].ToolCalls
+			Expect(toolCalls).To(HaveLen(1))
+			Expect(toolCalls[0].Type).To(Equal(openai.ToolTypeFunction))
+			Expect(toolCalls[0].Function.Name).To(Equal("get_weather"))
+			Expect(toolCalls[0].Function.Arguments).To(MatchJSON(json))
 		})
 	})
 })

--- a/mcp.go
+++ b/mcp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/mudler/xlog"
@@ -47,10 +48,7 @@ func (t *mcpTool) Execute(args map[string]any) (string, any, error) {
 		return "", nil, err
 	}
 
-	result := ""
-	for _, c := range res.Content {
-		result += c.(*mcp.TextContent).Text
-	}
+	result := contentToString(res.Content)
 
 	if res.IsError {
 		xlog.Error("tool failed", "result", result)
@@ -58,6 +56,39 @@ func (t *mcpTool) Execute(args map[string]any) (string, any, error) {
 	}
 
 	return result, res, nil
+}
+
+// contentToString flattens the content blocks of an MCP tool result into a
+// single textual representation that can be fed back to the model. Non-text
+// blocks (images, audio, resources) are summarized with a descriptive marker
+// instead of being asserted to *mcp.TextContent, which would panic and crash
+// the host process when a tool returns media (see mudler/LocalAI#10101).
+func contentToString(content []mcp.Content) string {
+	result := ""
+	for _, c := range content {
+		switch v := c.(type) {
+		case *mcp.TextContent:
+			result += v.Text
+		case *mcp.ImageContent:
+			result += fmt.Sprintf("[image content (%s), %d bytes]", v.MIMEType, len(v.Data))
+		case *mcp.AudioContent:
+			result += fmt.Sprintf("[audio content (%s), %d bytes]", v.MIMEType, len(v.Data))
+		case *mcp.ResourceLink:
+			result += fmt.Sprintf("[resource link: %s]", v.URI)
+		case *mcp.EmbeddedResource:
+			switch {
+			case v.Resource == nil:
+				result += "[embedded resource]"
+			case v.Resource.Text != "":
+				result += v.Resource.Text
+			default:
+				result += fmt.Sprintf("[embedded resource: %s]", v.Resource.URI)
+			}
+		default:
+			xlog.Warn("Unhandled MCP content type", "type", fmt.Sprintf("%T", c))
+		}
+	}
+	return result
 }
 
 func (t *mcpTool) Close() {

--- a/mcp_content_test.go
+++ b/mcp_content_test.go
@@ -1,0 +1,75 @@
+package cogito
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestContentToStringImageDoesNotPanic pins the fix for the crash reported in
+// mudler/LocalAI#10101: an MCP tool that returns a non-text content block (e.g.
+// an image from osmmcp's get_map_image) used to make contentToString panic with
+// "interface conversion: mcp.Content is *mcp.ImageContent, not *mcp.TextContent",
+// taking the whole process down. Mixed text + image content must be handled
+// gracefully instead.
+func TestContentToStringImageDoesNotPanic(t *testing.T) {
+	content := []mcp.Content{
+		&mcp.TextContent{Text: "here is your map: "},
+		&mcp.ImageContent{MIMEType: "image/png", Data: []byte("\x89PNGfakebytes")},
+	}
+
+	result := contentToString(content)
+
+	// The text block must still be preserved verbatim.
+	if !strings.Contains(result, "here is your map: ") {
+		t.Fatalf("expected text content to be preserved, got %q", result)
+	}
+	// The image block must contribute a descriptive, non-empty marker rather
+	// than panicking or being silently lost, so the model knows an image came back.
+	if !strings.Contains(result, "image/png") {
+		t.Fatalf("expected image mime type to surface in result, got %q", result)
+	}
+}
+
+// TestContentToStringTextOnly pins the original behavior: plain text blocks are
+// concatenated verbatim with no extra decoration.
+func TestContentToStringTextOnly(t *testing.T) {
+	content := []mcp.Content{
+		&mcp.TextContent{Text: "hello "},
+		&mcp.TextContent{Text: "world"},
+	}
+
+	if got := contentToString(content); got != "hello world" {
+		t.Fatalf("expected %q, got %q", "hello world", got)
+	}
+}
+
+// TestContentToStringEmbeddedResourceText surfaces the text of an embedded
+// resource so it remains usable by the model.
+func TestContentToStringEmbeddedResourceText(t *testing.T) {
+	content := []mcp.Content{
+		&mcp.EmbeddedResource{Resource: &mcp.ResourceContents{URI: "file://x", Text: "embedded body"}},
+	}
+
+	if got := contentToString(content); !strings.Contains(got, "embedded body") {
+		t.Fatalf("expected embedded resource text in result, got %q", got)
+	}
+}
+
+// TestContentToStringAudioAndResourceLink ensures the remaining non-text content
+// variants are summarized rather than panicking.
+func TestContentToStringAudioAndResourceLink(t *testing.T) {
+	content := []mcp.Content{
+		&mcp.AudioContent{MIMEType: "audio/wav", Data: []byte("RIFFfake")},
+		&mcp.ResourceLink{URI: "https://example.com/r"},
+	}
+
+	got := contentToString(content)
+	if !strings.Contains(got, "audio/wav") {
+		t.Fatalf("expected audio mime type in result, got %q", got)
+	}
+	if !strings.Contains(got, "https://example.com/r") {
+		t.Fatalf("expected resource link URI in result, got %q", got)
+	}
+}

--- a/tools.go
+++ b/tools.go
@@ -232,6 +232,41 @@ func normalizeSystemMessages(messages []openai.ChatCompletionMessage) []openai.C
 	return result
 }
 
+// mergeConsecutiveAssistantMessages collapses runs of two or more consecutive
+// assistant messages into a single assistant message. Some chat backends
+// (notably llama.cpp via LocalAI) reject a request whose message list ends with
+// two or more assistant messages in a row, failing with
+// "Cannot have 2 or more assistant messages at the end of the list".
+//
+// cogito's tool loop can legitimately append an assistant "reasoning" message
+// on top of a fragment that already ends with an assistant message, so the
+// conversation handed to a decision call must be normalized first. Merging
+// preserves all content and tool calls while guaranteeing the list never ends
+// with consecutive assistant messages.
+func mergeConsecutiveAssistantMessages(messages []openai.ChatCompletionMessage) []openai.ChatCompletionMessage {
+	if len(messages) < 2 {
+		return messages
+	}
+
+	merged := make([]openai.ChatCompletionMessage, 0, len(messages))
+	for _, msg := range messages {
+		if len(merged) > 0 && msg.Role == "assistant" && merged[len(merged)-1].Role == "assistant" {
+			prev := &merged[len(merged)-1]
+			if msg.Content != "" {
+				if prev.Content != "" {
+					prev.Content += "\n\n"
+				}
+				prev.Content += msg.Content
+			}
+			prev.ToolCalls = append(prev.ToolCalls, msg.ToolCalls...)
+			continue
+		}
+		merged = append(merged, msg)
+	}
+
+	return merged
+}
+
 // decisionWithStreaming is like decision but uses streaming when a StreamingLLM and
 // callback are available, forwarding reasoning/content/tool_call deltas live.
 // Falls back to decision() when streaming is not possible.
@@ -244,7 +279,7 @@ func decisionWithStreaming(ctx context.Context, llm LLM, conversation []openai.C
 	}
 
 	req := openai.ChatCompletionRequest{
-		Messages: normalizeSystemMessages(conversation),
+		Messages: mergeConsecutiveAssistantMessages(normalizeSystemMessages(conversation)),
 		Tools:    tools.ToOpenAI(),
 	}
 
@@ -373,7 +408,7 @@ func decision(ctx context.Context, llm LLM, conversation []openai.ChatCompletion
 	tools Tools, forceTool string, maxRetries int) (*decisionResult, error) {
 
 	decision := openai.ChatCompletionRequest{
-		Messages: normalizeSystemMessages(conversation),
+		Messages: mergeConsecutiveAssistantMessages(normalizeSystemMessages(conversation)),
 		Tools:    tools.ToOpenAI(),
 	}
 


### PR DESCRIPTION
An MCP tool result is a slice of mcp.Content, which may contain image, audio, resource-link or embedded-resource blocks in addition to text. mcpTool.Execute asserted every block to *mcp.TextContent unconditionally, so any tool returning media (e.g. osmmcp get_map_image, NASA image tools) triggered:

  panic: interface conversion: mcp.Content is *mcp.ImageContent, not *mcp.TextContent

The panic was on an agent goroutine with no recover, taking the whole host process down (mudler/LocalAI#10101).

Extract a contentToString helper that type-switches over every mcp.Content variant: text is concatenated verbatim (preserving prior behavior), media and resource blocks are summarized with a descriptive marker, and unknown types are logged instead of crashing.