### PR TITLE
fix(tools): abort retries on cancel

### DIFF
--- a/cancel_inflight_test.go
+++ b/cancel_inflight_test.go
@@ -1,0 +1,64 @@
+package cogito
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+// ctxBlockingLLM blocks every call until its context is cancelled (or a long
+// timeout), to verify that cancelling the execution context aborts an in-flight
+// LLM call rather than waiting for the call (or its retry backoff) to finish.
+type ctxBlockingLLM struct {
+	once    sync.Once
+	started chan struct{}
+}
+
+func newCtxBlockingLLM() *ctxBlockingLLM { return &ctxBlockingLLM{started: make(chan struct{})} }
+func (b *ctxBlockingLLM) sig()           { b.once.Do(func() { close(b.started) }) }
+func (b *ctxBlockingLLM) block(ctx context.Context) error {
+	b.sig()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(30 * time.Second):
+		return errors.New("LLM call was NOT cancelled — context not threaded")
+	}
+}
+func (b *ctxBlockingLLM) CreateChatCompletion(ctx context.Context, _ openai.ChatCompletionRequest) (LLMReply, LLMUsage, error) {
+	return LLMReply{}, LLMUsage{}, b.block(ctx)
+}
+func (b *ctxBlockingLLM) Ask(ctx context.Context, f Fragment) (Fragment, error) { return f, b.block(ctx) }
+
+type ctxNoopArgs struct{}
+type ctxNoopRunner struct{}
+
+func (ctxNoopRunner) Run(map[string]any) (string, any, error) { return "ok", nil, nil }
+
+func TestExecuteToolsAbortsInFlightLLMCall(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	llm := newCtxBlockingLLM()
+	tool := NewToolDefinition[map[string]any](ctxNoopRunner{}, ctxNoopArgs{}, "noop", "a no-op tool")
+	f := NewEmptyFragment().AddMessage(UserMessageRole, "do something")
+	done := make(chan error, 1)
+	go func() { _, err := ExecuteTools(llm, f, WithContext(ctx), WithTools(tool)); done <- err }()
+	select {
+	case <-llm.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ExecuteTools never reached the LLM call")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ExecuteTools did not return within 5s of cancel — in-flight call not aborted")
+	}
+}

--- a/tools.go
+++ b/tools.go
@@ -298,11 +298,17 @@ func decisionWithStreaming(ctx context.Context, llm LLM, conversation []openai.C
 
 	var lastErr error
 	for attempts := 0; attempts < maxRetries; attempts++ {
+		// Abort promptly if the execution context was cancelled.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		ch, err := sllm.CreateChatCompletionStream(ctx, req)
 		if err != nil {
 			lastErr = err
 			xlog.Warn("Streaming attempt to make a decision failed", "attempt", attempts+1, "error", err)
-			time.Sleep(time.Duration(attempts+1) * time.Second)
+			if werr := backoffOrCancel(ctx, attempts); werr != nil {
+				return nil, werr
+			}
 			continue
 		}
 
@@ -347,7 +353,9 @@ func decisionWithStreaming(ctx context.Context, llm LLM, conversation []openai.C
 		if streamErr != nil {
 			lastErr = streamErr
 			xlog.Warn("Streaming decision encountered error", "attempt", attempts+1, "error", streamErr)
-			time.Sleep(time.Duration(attempts+1) * time.Second)
+			if werr := backoffOrCancel(ctx, attempts); werr != nil {
+				return nil, werr
+			}
 			continue
 		}
 
@@ -366,7 +374,9 @@ func decisionWithStreaming(ctx context.Context, llm LLM, conversation []openai.C
 			if content == "" {
 				// Model produced no visible content (empty response or only reasoning) — retry
 				xlog.Warn("Streaming decision produced no content, retrying", "attempt", attempts+1)
-				time.Sleep(time.Duration(attempts+1) * time.Second)
+				if werr := backoffOrCancel(ctx, attempts); werr != nil {
+					return nil, werr
+				}
 				continue
 			}
 			return &decisionResult{message: content, reasoning: reasoning, usage: usage}, nil
@@ -390,7 +400,9 @@ func decisionWithStreaming(ctx context.Context, llm LLM, conversation []openai.C
 		}
 
 		if !allParsed {
-			time.Sleep(time.Duration(attempts+1) * time.Second)
+			if werr := backoffOrCancel(ctx, attempts); werr != nil {
+				return nil, werr
+			}
 			continue
 		}
 
@@ -404,6 +416,19 @@ func decisionWithStreaming(ctx context.Context, llm LLM, conversation []openai.C
 	}
 
 	return nil, fmt.Errorf("failed to make a streaming decision after %d attempts: %w", maxRetries, lastErr)
+}
+
+// backoffOrCancel waits the retry backoff for the given attempt, returning the
+// context error immediately if the context is cancelled during the wait. This
+// keeps the decision retry loops responsive to cancellation: a cancelled call
+// aborts at once instead of sleeping through the full backoff before retrying.
+func backoffOrCancel(ctx context.Context, attempt int) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(time.Duration(attempt+1) * time.Second):
+		return nil
+	}
 }
 
 // decision forces the LLM to make a tool choice with retry logic
@@ -427,18 +452,26 @@ func decision(ctx context.Context, llm LLM, conversation []openai.ChatCompletion
 
 	var lastErr error
 	for attempts := 0; attempts < maxRetries; attempts++ {
+		// Abort promptly if the execution context was cancelled.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		resp, usage, err := llm.CreateChatCompletion(ctx, decision)
 		if err != nil {
 			lastErr = err
 			xlog.Warn("Attempt to make a decision failed", "attempt", attempts+1, "error", err)
-			time.Sleep(time.Duration(attempts+1) * time.Second)
+			if werr := backoffOrCancel(ctx, attempts); werr != nil {
+				return nil, werr
+			}
 			continue
 		}
 
 		if len(resp.ChatCompletionResponse.Choices) != 1 {
 			lastErr = fmt.Errorf("no choices: %d", len(resp.ChatCompletionResponse.Choices))
 			xlog.Warn("Attempt to make a decision failed", "attempt", attempts+1, "error", lastErr)
-			time.Sleep(time.Duration(attempts+1) * time.Second)
+			if werr := backoffOrCancel(ctx, attempts); werr != nil {
+				return nil, werr
+			}
 			continue
 		}
 
@@ -460,7 +493,9 @@ func decision(ctx context.Context, llm LLM, conversation []openai.ChatCompletion
 			if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &arguments); err != nil {
 				lastErr = err
 				xlog.Warn("Attempt to parse tool arguments failed", "attempt", attempts+1, "error", err)
-				time.Sleep(time.Duration(attempts+1) * time.Second)
+				if werr := backoffOrCancel(ctx, attempts); werr != nil {
+					return nil, werr
+				}
 				continue
 			}
 


### PR DESCRIPTION

Cancellation responsiveness: the decision()/decisionWithStreaming() retry loops retried on any error (including context.Canceled) and slept the backoff non-cancellably between attempts. Bail out the moment the context is cancelled (check ctx.Err() each attempt + context-aware backoffOrCancel), so a cancelled in-flight LLM call surfaces context.Canceled promptly instead of sleeping through the full backoff.

Adds a unit test asserting ExecuteTools aborts an in-flight call on cancel. Branched off the commit wiz pins (67811fa) so it is testable end-to-end with wiz.