### PR TITLE
fix(agent): keep detached/background sub-agents alive after parent turn ends

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -347,7 +347,13 @@ func (r *spawnAgentRunner) Run(args SpawnAgentArgs) (string, any, error) {
 	subLLM := r.resolveLLM(args, def)
 
 	agentID := uuid.New().String()
-	subCtx, cancel := context.WithCancel(r.ctx)
+	// Decouple the sub-agent's lifetime from the parent turn's cancellation:
+	// once detached (or spawned in the background) the agent must keep running
+	// after the parent ExecuteTools call returns and the embedder cancels its
+	// per-turn context. WithoutCancel keeps the context's values while severing
+	// propagated cancellation. Foreground cancellation still works because the
+	// select below watches r.ctx.Done() directly and calls cancel() itself.
+	subCtx, cancel := context.WithCancel(context.WithoutCancel(r.ctx))
 
 	if !args.Background {
 		// Foreground: register the agent and run it in a goroutine so the

--- a/agent_detach_survive_test.go
+++ b/agent_detach_survive_test.go
@@ -1,0 +1,79 @@
+package cogito
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestDetachedAgentSurvivesParentCancel verifies that once a foreground
+// sub-agent is detached to the background, cancelling the parent turn's context
+// (as an embedder does when its ExecuteTools call returns) does NOT cancel the
+// detached agent: it keeps running and completes its work.
+//
+// Regression: previously the sub-agent context was a child of r.ctx, so the
+// embedder cancelling the per-turn context killed the just-detached agent.
+func TestDetachedAgentSurvivesParentCancel(t *testing.T) {
+	m := NewAgentManager()
+	release := make(chan struct{})
+	llm := newBlockingLLM(release)
+
+	parentCtx, cancelParent := context.WithCancel(context.Background())
+	runner := &spawnAgentRunner{llm: llm, manager: m, ctx: parentCtx}
+
+	idCh := make(chan any, 1)
+	go func() {
+		_, id, _ := runner.Run(SpawnAgentArgs{Task: "long job", Background: false})
+		idCh <- id
+	}()
+
+	// Wait for the foreground agent to register, then detach it.
+	var id string
+	deadline := time.After(2 * time.Second)
+	for id == "" {
+		if agents := m.List(); len(agents) == 1 {
+			id = agents[0].ID
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("foreground agent never registered")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	if err := m.Detach(id); err != nil {
+		t.Fatalf("detach errored: %v", err)
+	}
+	if rid := <-idCh; rid == nil {
+		t.Fatal("expected detach to return the agent id")
+	}
+
+	// Simulate the embedder cancelling the per-turn context now that the parent
+	// ExecuteTools call has returned. The detached agent must survive this.
+	cancelParent()
+
+	// Give any erroneous cancellation a chance to propagate, then let the agent
+	// finish its work.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+
+	// The agent should reach Completed (not Failed/cancelled).
+	completeBy := time.After(2 * time.Second)
+	for {
+		a, ok := m.Get(id)
+		if ok && a.Status == AgentStatusCompleted {
+			if a.Result != llm.reply {
+				t.Fatalf("unexpected result: got %q want %q", a.Result, llm.reply)
+			}
+			return
+		}
+		if ok && a.Status == AgentStatusFailed {
+			t.Fatalf("detached agent was cancelled/failed after parent cancel: %v", a.Error)
+		}
+		select {
+		case <-completeBy:
+			t.Fatal("detached agent did not complete after parent cancel")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}

--- a/cancel_inflight_test.go
+++ b/cancel_inflight_test.go
@@ -32,7 +32,9 @@ func (b *ctxBlockingLLM) block(ctx context.Context) error {
 func (b *ctxBlockingLLM) CreateChatCompletion(ctx context.Context, _ openai.ChatCompletionRequest) (LLMReply, LLMUsage, error) {
 	return LLMReply{}, LLMUsage{}, b.block(ctx)
 }
-func (b *ctxBlockingLLM) Ask(ctx context.Context, f Fragment) (Fragment, error) { return f, b.block(ctx) }
+func (b *ctxBlockingLLM) Ask(ctx context.Context, f Fragment) (Fragment, error) {
+	return f, b.block(ctx)
+}
 
 type ctxNoopArgs struct{}
 type ctxNoopRunner struct{}


### PR DESCRIPTION
A sub-agent's context was a child of the parent turn context (r.ctx), so when an embedder cancelled its per-turn context right after ExecuteTools returned — the normal end-of-turn cleanup — a just-detached (or background) agent was cancelled too, defeating the whole point of detaching.

Parent the sub-agent context off context.WithoutCancel(r.ctx): it keeps the context's values but no longer propagates the parent's cancellation. Foreground cancellation is unaffected because the foreground select already watches r.ctx.Done() and calls cancel() explicitly; detached and background agents now run to completion independently and remain cancellable via AgentState.Cancel.

Add TestDetachedAgentSurvivesParentCancel, which fails on the old behavior (agent cancelled after parent cancel) and passes now.