### PR TITLE
pickTool: name the chosen tool in the error and match tool names leniently

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -133,13 +133,41 @@ func (t *ToolDefinition[T]) Execute(args map[string]any) (string, any, error) {
 
 type Tools []ToolDefinitionInterface
 
+// Find returns the tool whose function name matches name. It first tries an
+// exact match (fast path, unchanged behavior). If none is found, it falls back
+// to a lenient match: local models frequently emit namespaced/case/separator
+// variants (e.g. "functions.foo", "tools/foo", "Foo", "foo-bar" for "foo_bar").
+// The lenient pass never overrides an exact match, so existing resolutions are
+// unaffected.
 func (t Tools) Find(name string) ToolDefinitionInterface {
 	for _, tool := range t {
 		if tool.Tool().Function.Name == name {
 			return tool
 		}
 	}
+	norm := normalizeToolName(name)
+	if norm == "" {
+		return nil
+	}
+	for _, tool := range t {
+		if normalizeToolName(tool.Tool().Function.Name) == norm {
+			return tool
+		}
+	}
 	return nil
+}
+
+// normalizeToolName reduces a tool name to a comparison key: it drops a leading
+// namespace segment ("functions.", "tools/", "namespace::"), lower-cases, trims
+// spaces, and treats '-' and '_' as equivalent. Used only as a lenient fallback
+// in Find; it never affects exact-match resolution.
+func normalizeToolName(s string) string {
+	if i := strings.LastIndexAny(s, "./:"); i >= 0 {
+		s = s[i+1:] // segment after the last separator (may be empty → empty key)
+	}
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = strings.ReplaceAll(s, "-", "_")
+	return s
 }
 
 func (t Tools) ToOpenAI() []openai.Tool {
@@ -821,7 +849,7 @@ func pickTool(ctx context.Context, llm LLM, fragment Fragment, tools Tools, opts
 		chosenTool := tools.Find(intentionResponse.Tool)
 		if chosenTool == nil {
 			xlog.Debug("[pickTool] Chosen tool not found", "tool", intentionResponse.Tool)
-			return nil, fmt.Errorf("chosen tool not found")
+			return nil, fmt.Errorf("chosen tool %q not found", intentionResponse.Tool)
 		}
 
 		toolChoices = append(toolChoices, &ToolChoice{

--- a/tools_lenient_test.go
+++ b/tools_lenient_test.go
@@ -1,0 +1,61 @@
+package cogito
+
+import "testing"
+
+func TestNormalizeToolName(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"foo", "foo"},
+		{"Foo", "foo"},
+		{"functions.foo", "foo"},
+		{"tools/foo", "foo"},
+		{"namespace::foo", "foo"},
+		{"foo-bar", "foo_bar"},
+		{"Foo-Bar", "foo_bar"},
+		{"functions.Coach_Regeln", "coach_regeln"},
+		{"  foo  ", "foo"},
+		{"", ""},
+		{"functions.", ""}, // nothing after the separator → empty key
+	}
+	for _, c := range cases {
+		if got := normalizeToolName(c.in); got != c.want {
+			t.Errorf("normalizeToolName(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestFindLenient(t *testing.T) {
+	tools := Tools{newNamedTool("coach_regeln")}
+
+	// exact + lenient variants local models routinely emit
+	for _, n := range []string{
+		"coach_regeln",           // exact
+		"functions.coach_regeln", // namespaced
+		"tools/coach_regeln",
+		"Coach_Regeln", // case
+		"coach-regeln", // separator
+	} {
+		if tools.Find(n) == nil {
+			t.Errorf("Find(%q) = nil, want match", n)
+		}
+	}
+
+	for _, n := range []string{"other_tool", "", "functions."} {
+		if tools.Find(n) != nil {
+			t.Errorf("Find(%q) matched, want nil", n)
+		}
+	}
+}
+
+// An exact match must always win, even when a lenient candidate appears earlier
+// in the slice — the lenient pass is a fallback, never an override.
+func TestFindExactWinsOverLenient(t *testing.T) {
+	tools := Tools{newNamedTool("functions.foo"), newNamedTool("foo")}
+	got := tools.Find("foo")
+	if got == nil || got.Tool().Function.Name != "foo" {
+		name := "<nil>"
+		if got != nil {
+			name = got.Tool().Function.Name
+		}
+		t.Errorf(`Find("foo") = %q, want exact "foo"`, name)
+	}
+}


### PR DESCRIPTION
Two small, related robustness fixes in `tools.go` for local-model tool selection. We hit these repeatedly in production (agent pool via LocalAI) — 4 hard turn-failures in one evening across two different Qwen-class local models.

### 1. The error hides the chosen name (`pickTool`)
When the model's chosen tool can't be resolved, `pickTool` returned a bare `chosen tool not found`. The name was only `xlog.Debug`-logged, so operators running at info level saw repeated failures with zero diagnosability. Now: `chosen tool %q not found`.

### 2. `Tools.Find` matched exact-only
Local models routinely emit namespaced / case / separator variants — `functions.coach_regeln`, `Coach_Regeln`, `tools/coach_regeln` — each of which missed and became a hard failure. `Find` now keeps exact match as the fast path and adds a **lenient fallback that only triggers on a miss**: it strips a leading namespace segment (`functions.`/`tools/`/`ns::`), case-folds, and treats `-` ≡ `_`. When an exact match exists it is always returned, so existing resolutions are unaffected (covered by a test).

### Tests
Table-driven tests for `normalizeToolName`, lenient `Find`, and the exact-wins-over-lenient guarantee. `go test`, `go vet`, `gofmt` clean.

Related in spirit to #60 / #62: helper/selection steps benefit from diagnosability and tolerance of model quirks. Happy to adjust (e.g. gate the lenient match behind an option) if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
