### PR TITLE
fix(tools): recover forced-tool arguments when the backend ignores tool_choice

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -343,7 +343,8 @@ func decisionWithStreaming(ctx context.Context, llm LLM, conversation []openai.C
 				// with thinking disabled) free-run plain text to the token cap
 				// instead — detectable within a few hundred bytes. Abort the
 				// doomed stream early and recover via the schema fallback.
-				if forceTool != "" && len(toolCallMap) == 0 && contentBuf.Len() > forcedContentAbortBytes {
+				if forceTool != "" && len(toolCallMap) == 0 && contentBuf.Len() > forcedContentAbortBytes &&
+					prosaBeyondThink(contentBuf.String()) > forcedContentAbortBytes {
 					forcedIgnored = true
 					scancel()
 				}
@@ -506,6 +507,25 @@ func backoffOrCancel(ctx context.Context, attempt int) error {
 // template preambles; small enough to abort within seconds instead of
 // free-running to the generation cap.
 const forcedContentAbortBytes = 512
+
+// prosaBeyondThink returns the length of plain prose outside a leading
+// <think>…</think> block. Some pipelines deliver a thinking model's reasoning
+// as ordinary content deltas rather than reasoning events; while such a block
+// is still open, the stream must NOT be treated as violating a forced
+// tool_choice — thinking models legitimately reason at length before emitting
+// the (honored) forced call. Only prose after the closing tag — or without any
+// think block — counts toward the abort threshold.
+func prosaBeyondThink(s string) int {
+	t := strings.TrimSpace(s)
+	if strings.HasPrefix(t, "<think>") {
+		idx := strings.Index(t, "</think>")
+		if idx < 0 {
+			return 0 // still inside the reasoning block
+		}
+		return len(strings.TrimSpace(t[idx+len("</think>"):]))
+	}
+	return len(t)
+}
 
 // forcedToolParamsViaSchema recovers the arguments of a forced tool when the
 // backend did not honor a named/required tool_choice. Some llama.cpp chat

--- a/tools.go
+++ b/tools.go
@@ -400,6 +400,17 @@ func decisionWithStreaming(ctx context.Context, llm LLM, conversation []openai.C
 				}
 				continue
 			}
+			if forceTool != "" {
+				// The backend ignored the forced tool_choice (some llama.cpp
+				// templates do, see forcedToolParamsViaSchema) — recover the
+				// arguments through the structured-output grammar path.
+				if tc, ferr := forcedToolParamsViaSchema(ctx, llm, conversation, tools, forceTool); ferr == nil {
+					xlog.Warn("[decisionWithStreaming] forced tool_choice not honored by backend — arguments recovered via response_format schema fallback", "tool", forceTool)
+					return &decisionResult{toolChoices: []*ToolChoice{tc}, message: content, reasoning: reasoning, usage: usage}, nil
+				} else {
+					xlog.Warn("[decisionWithStreaming] schema fallback for forced tool failed", "tool", forceTool, "error", ferr)
+				}
+			}
 			return &decisionResult{message: content, reasoning: reasoning, usage: usage}, nil
 		}
 
@@ -452,6 +463,67 @@ func backoffOrCancel(ctx context.Context, attempt int) error {
 	}
 }
 
+// forcedToolParamsViaSchema recovers the arguments of a forced tool when the
+// backend did not honor a named/required tool_choice. Some llama.cpp chat
+// templates ignore the tool_choice constraint at generation time and free-run
+// plain text instead (observed with Qwen3-family templates when thinking is
+// disabled via chat_template_kwargs), so a forced decision returns without any
+// tool call. Re-asking with a response_format JSON schema — built from the
+// forced tool's parameter schema — goes through the plain structured-output
+// grammar path, which those templates do honor, and yields the arguments
+// deterministically. Backend-agnostic: only used as a fallback when the forced
+// decision produced no tool call, so well-behaved backends never take it.
+func forcedToolParamsViaSchema(ctx context.Context, llm LLM, conversation []openai.ChatCompletionMessage,
+	tools Tools, forceTool string) (*ToolChoice, error) {
+	var params any
+	found := false
+	for _, t := range tools.ToOpenAI() {
+		if t.Function != nil && t.Function.Name == forceTool {
+			params = t.Function.Parameters
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, fmt.Errorf("forced tool %q not among available tools", forceTool)
+	}
+	schema, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("marshal parameter schema of %q: %w", forceTool, err)
+	}
+
+	req := openai.ChatCompletionRequest{
+		Messages: append(mergeConsecutiveAssistantMessages(normalizeSystemMessages(conversation)),
+			openai.ChatCompletionMessage{
+				Role: "system",
+				Content: fmt.Sprintf(
+					"Generate ONLY the JSON arguments for calling the tool %q, matching its parameter schema. No prose.",
+					forceTool),
+			}),
+		ResponseFormat: &openai.ChatCompletionResponseFormat{
+			Type: openai.ChatCompletionResponseFormatTypeJSONSchema,
+			JSONSchema: &openai.ChatCompletionResponseFormatJSONSchema{
+				Name:   "tool_arguments",
+				Schema: json.RawMessage(schema),
+				Strict: true,
+			},
+		},
+	}
+
+	reply, _, err := llm.CreateChatCompletion(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if len(reply.ChatCompletionResponse.Choices) == 0 {
+		return nil, fmt.Errorf("schema fallback returned no choices")
+	}
+	arguments := map[string]any{}
+	if err := json.Unmarshal([]byte(reply.ChatCompletionResponse.Choices[0].Message.Content), &arguments); err != nil {
+		return nil, fmt.Errorf("schema fallback content is not valid JSON: %w", err)
+	}
+	return &ToolChoice{Name: forceTool, Arguments: arguments}, nil
+}
+
 // decision forces the LLM to make a tool choice with retry logic
 // Similar to agent.go's decision function but adapted for cogito's architecture
 func decision(ctx context.Context, llm LLM, conversation []openai.ChatCompletionMessage,
@@ -502,6 +574,17 @@ func decision(ctx context.Context, llm LLM, conversation []openai.ChatCompletion
 		xlog.Debug("[decision] processed", "message", msg.Content, "reasoning", reasoning)
 
 		if len(msg.ToolCalls) == 0 {
+			if forceTool != "" {
+				// The backend ignored the forced tool_choice (some llama.cpp
+				// templates do, see forcedToolParamsViaSchema) — recover the
+				// arguments through the structured-output grammar path.
+				if tc, ferr := forcedToolParamsViaSchema(ctx, llm, conversation, tools, forceTool); ferr == nil {
+					xlog.Warn("[decision] forced tool_choice not honored by backend — arguments recovered via response_format schema fallback", "tool", forceTool)
+					return &decisionResult{toolChoices: []*ToolChoice{tc}, message: msg.Content, reasoning: reasoning, usage: usage}, nil
+				} else {
+					xlog.Warn("[decision] schema fallback for forced tool failed", "tool", forceTool, "error", ferr)
+				}
+			}
 			// No tool call - the LLM just responded with text
 			return &decisionResult{message: msg.Content, reasoning: reasoning, usage: usage}, nil
 		}

--- a/tools.go
+++ b/tools.go
@@ -308,8 +308,13 @@ func decisionWithStreaming(ctx context.Context, llm LLM, conversation []openai.C
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		ch, err := sllm.CreateChatCompletionStream(ctx, req)
+		// Cancellable per attempt so a forced decision whose constraint the
+		// backend ignores can be aborted early (see forcedIgnored below)
+		// instead of free-running to the generation cap.
+		sctx, scancel := context.WithCancel(ctx)
+		ch, err := sllm.CreateChatCompletionStream(sctx, req)
 		if err != nil {
+			scancel()
 			lastErr = err
 			xlog.Warn("Streaming attempt to make a decision failed", "attempt", attempts+1, "error", err)
 			if werr := backoffOrCancel(ctx, attempts); werr != nil {
@@ -325,12 +330,23 @@ func decisionWithStreaming(ctx context.Context, llm LLM, conversation []openai.C
 		var streamErr error
 		var usage LLMUsage
 		var finishReason string
+		forcedIgnored := false
 
 		for ev := range ch {
 			streamCB(ev)
 			switch ev.Type {
 			case StreamEventContent:
 				contentBuf.WriteString(ev.Content)
+				// A honored forced tool_choice emits tool-call deltas, not
+				// prose (reasoning streams separately and is fine). Backends
+				// that ignore the constraint (llama.cpp Qwen3-family templates
+				// with thinking disabled) free-run plain text to the token cap
+				// instead — detectable within a few hundred bytes. Abort the
+				// doomed stream early and recover via the schema fallback.
+				if forceTool != "" && len(toolCallMap) == 0 && contentBuf.Len() > forcedContentAbortBytes {
+					forcedIgnored = true
+					scancel()
+				}
 			case StreamEventReasoning:
 				reasoningBuf.WriteString(ev.Content)
 			case StreamEventToolCall:
@@ -355,6 +371,26 @@ func decisionWithStreaming(ctx context.Context, llm LLM, conversation []openai.C
 				finishReason = ev.FinishReason
 			case StreamEventError:
 				streamErr = ev.Error
+			}
+		}
+
+		scancel()
+
+		if forcedIgnored {
+			// Deliberately aborted: the backend streamed prose instead of the
+			// forced tool call. Recover the arguments through the structured-
+			// output grammar path instead of letting the free-run reach the
+			// generation cap first.
+			if tc, ferr := forcedToolParamsViaSchema(ctx, llm, conversation, tools, forceTool); ferr == nil {
+				xlog.Warn("[decisionWithStreaming] forced tool_choice not honored by backend — stream aborted early, arguments recovered via response_format schema fallback", "tool", forceTool)
+				return &decisionResult{toolChoices: []*ToolChoice{tc}, message: "", reasoning: reasoningBuf.String(), usage: usage}, nil
+			} else {
+				lastErr = fmt.Errorf("schema fallback after aborted forced stream failed: %w", ferr)
+				xlog.Warn("[decisionWithStreaming] schema fallback after aborted forced stream failed", "tool", forceTool, "error", ferr)
+				if werr := backoffOrCancel(ctx, attempts); werr != nil {
+					return nil, werr
+				}
+				continue
 			}
 		}
 
@@ -462,6 +498,14 @@ func backoffOrCancel(ctx context.Context, attempt int) error {
 		return nil
 	}
 }
+
+// forcedContentAbortBytes: a honored forced tool_choice streams tool-call
+// deltas, not prose. Once this much plain content has arrived without a single
+// tool-call delta, the constraint is evidently being ignored and the stream is
+// aborted in favor of the schema fallback. Generous enough to tolerate brief
+// template preambles; small enough to abort within seconds instead of
+// free-running to the generation cap.
+const forcedContentAbortBytes = 512
 
 // forcedToolParamsViaSchema recovers the arguments of a forced tool when the
 // backend did not honor a named/required tool_choice. Some llama.cpp chat

--- a/tools_forced_fallback_test.go
+++ b/tools_forced_fallback_test.go
@@ -98,3 +98,21 @@ func TestDecisionUnforcedTextStaysText(t *testing.T) {
 		t.Fatalf("expected exactly 1 LLM call, got %d", len(llm.calls))
 	}
 }
+
+// prosaBeyondThink: reasoning streamed as content must not trigger the
+// forced-stream abort while the think block is open; prose after it counts.
+func TestProsaBeyondThink(t *testing.T) {
+	long := make([]byte, 2000)
+	for i := range long {
+		long[i] = 'x'
+	}
+	if got := prosaBeyondThink("<think>" + string(long)); got != 0 {
+		t.Fatalf("open think block must count 0, got %d", got)
+	}
+	if got := prosaBeyondThink("<think>abc</think>  tail"); got != len("tail") {
+		t.Fatalf("post-think prose miscounted: %d", got)
+	}
+	if got := prosaBeyondThink(string(long)); got != 2000 {
+		t.Fatalf("plain prose miscounted: %d", got)
+	}
+}

--- a/tools_forced_fallback_test.go
+++ b/tools_forced_fallback_test.go
@@ -1,0 +1,100 @@
+package cogito
+
+import (
+	"context"
+
+	"testing"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+// forcedFallbackLLM simulates a backend whose forced (named) tool_choice is
+// NOT honored at generation time — as observed with llama.cpp Qwen3-family
+// templates when thinking is disabled: the forced decision comes back as plain
+// text without tool calls, while a response_format JSON-schema request is
+// honored and yields the arguments.
+type forcedFallbackLLM struct {
+	calls []openai.ChatCompletionRequest
+}
+
+func (l *forcedFallbackLLM) Ask(ctx context.Context, f Fragment) (Fragment, error) {
+	return f, nil
+}
+
+func (l *forcedFallbackLLM) CreateChatCompletion(ctx context.Context, req openai.ChatCompletionRequest) (LLMReply, LLMUsage, error) {
+	l.calls = append(l.calls, req)
+	msg := openai.ChatCompletionMessage{Role: "assistant"}
+	if req.ResponseFormat != nil && req.ResponseFormat.Type == openai.ChatCompletionResponseFormatTypeJSONSchema {
+		// The structured-output grammar path IS honored.
+		msg.Content = `{"query":"Siemens Gründungsjahr"}`
+	} else {
+		// Forced tool_choice ignored: free-text answer, no tool calls.
+		msg.Content = "Siemens wurde 1847 gegründet."
+	}
+	return LLMReply{
+		ChatCompletionResponse: openai.ChatCompletionResponse{
+			Choices: []openai.ChatCompletionChoice{{Message: msg}},
+		},
+	}, LLMUsage{}, nil
+}
+
+type fallbackTestArgs struct {
+	Query string `json:"query" description:"the research query"`
+}
+
+type fallbackTestTool struct{}
+
+func (fallbackTestTool) Run(args fallbackTestArgs) (string, any, error) { return "", nil, nil }
+
+func testTool() Tools {
+	return Tools{NewToolDefinition(fallbackTestTool{}, fallbackTestArgs{}, "assist", "web research")}
+}
+
+// TestDecisionForcedToolSchemaFallback: when the backend returns no tool call
+// for a forced tool, decision() must recover the arguments via the
+// response_format schema fallback instead of returning a text-only result
+// (which the callers surface as "no parameters generated for tool X").
+func TestDecisionForcedToolSchemaFallback(t *testing.T) {
+	llm := &forcedFallbackLLM{}
+	res, err := decision(context.Background(), llm,
+		[]openai.ChatCompletionMessage{{Role: "user", Content: "Wann wurde Siemens gegründet?"}},
+		testTool(), "assist", 1)
+	if err != nil {
+		t.Fatalf("decision failed: %v", err)
+	}
+	if len(res.toolChoices) != 1 {
+		t.Fatalf("expected 1 recovered tool choice, got %d (message=%q)", len(res.toolChoices), res.message)
+	}
+	tc := res.toolChoices[0]
+	if tc.Name != "assist" {
+		t.Fatalf("expected tool 'assist', got %q", tc.Name)
+	}
+	if q, _ := tc.Arguments["query"].(string); q == "" {
+		t.Fatalf("expected non-empty query argument, got %v", tc.Arguments)
+	}
+	// Exactly two calls: the (ignored) forced decision + the schema fallback.
+	if len(llm.calls) != 2 {
+		t.Fatalf("expected 2 LLM calls (forced + fallback), got %d", len(llm.calls))
+	}
+	if llm.calls[1].ResponseFormat == nil || llm.calls[1].ResponseFormat.Type != openai.ChatCompletionResponseFormatTypeJSONSchema {
+		t.Fatalf("fallback call did not use response_format json_schema")
+	}
+}
+
+// Without a forced tool, a text-only answer must stay a text-only decision —
+// the fallback must never fire for tool_choice=auto flows.
+func TestDecisionUnforcedTextStaysText(t *testing.T) {
+	llm := &forcedFallbackLLM{}
+	res, err := decision(context.Background(), llm,
+		[]openai.ChatCompletionMessage{{Role: "user", Content: "Wann wurde Siemens gegründet?"}},
+		testTool(), "", 1)
+	if err != nil {
+		t.Fatalf("decision failed: %v", err)
+	}
+	if len(res.toolChoices) != 0 {
+		t.Fatalf("expected no tool choices for unforced text answer, got %d", len(res.toolChoices))
+	}
+	if len(llm.calls) != 1 {
+		t.Fatalf("expected exactly 1 LLM call, got %d", len(llm.calls))
+	}
+}


### PR DESCRIPTION
## What

Some OpenAI-compatible backends do not honor a named/required `tool_choice` at generation time. We hit this with llama.cpp: Qwen3-family chat templates with thinking disabled via `chat_template_kwargs` ignore the constraint entirely and free-run plain text (reported upstream to llama.cpp with a minimal repro). For cogito this was fatal: every forced decision in `decision()`/`decisionWithStreaming()` came back without tool calls, surfaced as `no parameters generated for tool X`, and retried until the generation cap — the whole tool loop died in minutes-long narration loops.

Three backend-agnostic hardening steps, none of which change behavior on well-behaved backends:

1. **Schema fallback** (`forcedToolParamsViaSchema`): when a forced decision yields no tool call, re-ask with a `response_format` JSON schema built from the forced tool's parameter schema — the plain structured-output grammar path, which the affected templates do honor — and parse the arguments from the content.
2. **Early abort**: a honored forced call streams tool-call deltas, not prose. Once 512 bytes of plain content arrive without a single tool-call delta, cancel the stream and go straight to the fallback instead of free-running to the cap (minutes at local inference speeds).
3. **Think-aware**: prose inside a leading `<think>…</think>` block does not count toward the abort threshold — thinking models that legitimately reason at length before an honored forced call are unaffected (reasoning deltas never counted anyway; this covers pipelines that deliver reasoning as content).

## Testing

Unit tests cover: fallback fires exactly once for a forced no-call decision and recovers valid arguments; unforced text answers never take the fallback; the think-block prose counter. Verified end-to-end on a LocalAI + llama.cpp deployment where the agent tool loop went from all-red (retry-to-cap on every task) to 8/10 tasks passing with 10/10 clean finalizations.

Assisted-by: Claude (Anthropic) — implementation done with AI assistance; the failure analysis, repro and end-to-end verification were performed against real hardware.